### PR TITLE
Respond to delete event

### DIFF
--- a/DeleteCFStack/index.js
+++ b/DeleteCFStack/index.js
@@ -1,13 +1,13 @@
 const AWS = require('aws-sdk');
 const cf = new AWS.CloudFormation();
 
-function parsewebhookBody(eventType, webhookBody) {
+function parseWebhookBody(eventType, webhookBody) {
   let shouldDeleteStack, branchName, repoName;
 
   if (eventType === 'pull_request') {
     branchName = webhookBody['pull_request']['head']['ref'];
     repoName = webhookBody['pull_request']['head']['repo']['name'];
-    shouldDeleteStack = webhookBody['action'] === 'closed' && branchName != 'master'
+    shouldDeleteStack = webhookBody['action'] === 'closed' && branchName !== 'master';
   } else if (eventType === 'delete') {
     branchName = webhookBody['ref'];
     repoName = webhookBody['repository']['name'];
@@ -25,7 +25,7 @@ async function handleWebhookEvent(eventType, webhookBody) {
     return { statusCode: 200, message: message };
   }
 
-  const { shouldDeleteStack, stackName } = parsewebhookBody(eventType, webhookBody);
+  const { shouldDeleteStack, stackName } = parseWebhookBody(eventType, webhookBody);
 
   if (!shouldDeleteStack) {
     const message = `Event should not delete stack: shouldDeleteStack: ${shouldDeleteStack}, eventType: ${eventType}`;
@@ -46,7 +46,7 @@ async function handleWebhookEvent(eventType, webhookBody) {
 module.exports.handler = async (event, context) => {
   console.log(`Event: ${JSON.stringify(event, null, 2)}`);
   let response;
-
+parseWebhookBody
   if (!event.body) {
       response = { statusCode: 403, body: 'Missing event body' };
       console.log(`Response: ${JSON.stringify(response, null, 2)}`);

--- a/DeleteCFStack/index.js
+++ b/DeleteCFStack/index.js
@@ -1,64 +1,75 @@
 const AWS = require('aws-sdk');
 const cf = new AWS.CloudFormation();
 
-async function handleWebhookEvent(webhookBody) {
-    const action = webhookBody['action'];
-    const pullRequest = webhookBody['pull_request'];
-    let message = 'Event ignored';
+function parsewebhookBody(eventType, webhookBody) {
+  let shouldDeleteStack, branchName, repoName;
 
-    // If no pull_request, ignore event
-    if(!pullRequest) {
-        return { statusCode: 200, message: message };
-    }
+  if (eventType === 'pull_request') {
+    branchName = webhookBody['pull_request']['head']['ref'];
+    repoName = webhookBody['pull_request']['head']['repo']['name'];
+    shouldDeleteStack = webhookBody['action'] === 'closed' && branchName != 'master'
+  } else if (eventType === 'delete') {
+    branchName = webhookBody['ref'];
+    repoName = webhookBody['repository']['name'];
+    shouldDeleteStack = webhookBody['ref_type'] === 'branch' && branchName !== 'master';
+  };
 
-    const branchName = pullRequest['head']['ref'];
-    const repoName = pullRequest['head']['repo']['name'];
-
-    console.log({action});
-    console.log({branchName});
-
-    if(action === 'closed' && branchName != 'master') {
-        const stackNameRepo = `${branchName}-${repoName}`;
-        const stackNameDev = `${stackNameRepo}-dev`;
-        const stackNameTest = `${stackNameRepo}-test`;
-        // Delete the stacks
-        await cf.deleteStack({StackName: stackNameRepo}).promise();
-        await cf.deleteStack({StackName: stackNameDev}).promise();
-        await cf.deleteStack({StackName: stackNameTest}).promise();
-        message = `CloudFormation Stacks deleted: ${stackNameRepo}, ${stackNameDev}, ${stackNameTest}`;
-    } else {
-        message = "Pull request event ignored";
-    }
-    return { statusCode: 200, body: message };
+  console.log('shouldDeleteStack', shouldDeleteStack);
+  const stackName = `${branchName}-${repoName}`
+  return { shouldDeleteStack, stackName }
 }
 
+async function handleWebhookEvent(eventType, webhookBody) {
+  if(!['pull_request', 'delete'].includes(eventType)) {
+    const message = `Event ignored. Event type: ${eventType}`;
+    return { statusCode: 200, message: message };
+  }
+
+  const { shouldDeleteStack, stackName } = parsewebhookBody(eventType, webhookBody);
+
+  if (!shouldDeleteStack) {
+    const message = `Event should not delete stack: shouldDeleteStack: ${shouldDeleteStack}, eventType: ${eventType}`;
+    return { statusCode: 200, message: message };
+  } else {
+    // Delete the stacks
+    const stackNameDev = `${stackName}-dev`;
+    const stackNameTest = `${stackName}-test`;
+    await cf.deleteStack({StackName: stackName}).promise();
+    await cf.deleteStack({StackName: stackNameDev}).promise();
+    await cf.deleteStack({StackName: stackNameDev}).promise();
+
+    const message = `CloudFormation Stacks deleted: ${stackName}, ${stackNameDev}, ${stackNameTest}`;
+    return { statusCode: 200, message: message };
+  }
+};
+
 module.exports.handler = async (event, context) => {
-    console.log(`Event: ${JSON.stringify(event, null, 2)}`);
-    let response;
+  console.log(`Event: ${JSON.stringify(event, null, 2)}`);
+  let response;
 
-    if (!event.body) {
-        response = { statusCode: 403, body: 'Missing event body' };
-        console.log(`Response: ${JSON.stringify(response, null, 2)}`);
-        return response;
-    }
+  if (!event.body) {
+      response = { statusCode: 403, body: 'Missing event body' };
+      console.log(`Response: ${JSON.stringify(response, null, 2)}`);
+      return response;
+  }
 
+  let body;
+
+  try {
     // Parse the message body from the Lambda proxy
-    let body;
+    body = JSON.parse(event.body);
+  } catch (e) {
+    console.log(`Request Event Body is not JSON: ${event.body}`)
+    console.log(`Error: ${e}`)
+    response = { statusCode: 200, body: 'Event body is not JSON, Ignoring event' };
+    return response
+  }
 
-    try {
-      body = JSON.parse(event.body);
-    } catch (e) {
-      console.log(`Request Event Body is not JSON: ${event.body}`)
-      console.log(`Error: ${e}`)
-      response = { statusCode: 200, body: 'Event body is not JSON, Ignoring event' };
-      return response
-    }
+  console.log(`Event body: ${JSON.stringify(body, null, 2)}`);
 
-    console.log(`Event body: ${JSON.stringify(body, null, 2)}`);
+  const gitHubEvent = event.headers['X-GitHub-Event'];
+  response = await handleWebhookEvent(gitHubEvent, body);
 
-    // Handle the webhook event
-    response = await handleWebhookEvent(body);
-
-    console.log(`Response: ${JSON.stringify(response, null, 2)}`);
-    return response;
+  console.log(`Response: ${JSON.stringify(response, null, 2)}`);
+  return response;
 };

--- a/DeleteCFStack/index.js
+++ b/DeleteCFStack/index.js
@@ -22,14 +22,14 @@ function parseWebhookBody(eventType, webhookBody) {
 async function handleWebhookEvent(eventType, webhookBody) {
   if(!['pull_request', 'delete'].includes(eventType)) {
     const message = `Event ignored. Event type: ${eventType}`;
-    return { statusCode: 200, message: message };
+    return { statusCode: 200, body: message };
   }
 
   const { shouldDeleteStack, stackName } = parseWebhookBody(eventType, webhookBody);
 
   if (!shouldDeleteStack) {
     const message = `Event should not delete stack: shouldDeleteStack: ${shouldDeleteStack}, eventType: ${eventType}`;
-    return { statusCode: 200, message: message };
+    return { statusCode: 200, body: message };
   } else {
     // Delete the stacks
     const stackNameDev = `${stackName}-dev`;
@@ -39,7 +39,7 @@ async function handleWebhookEvent(eventType, webhookBody) {
     await cf.deleteStack({StackName: stackNameDev}).promise();
 
     const message = `CloudFormation Stacks deleted: ${stackName}, ${stackNameDev}, ${stackNameTest}`;
-    return { statusCode: 200, message: message };
+    return { statusCode: 200, body: message };
   }
 };
 

--- a/DeleteS3FeatureBucket/index.js
+++ b/DeleteS3FeatureBucket/index.js
@@ -23,7 +23,7 @@ async function deleteS3Bucket(bucket) {
   return message = `S3 bucket deleted: ${bucket}`;
 };
 
-function parsewebhookBody(eventType, webhookBody) {
+function parseWebhookBody(eventType, webhookBody) {
   let shouldDeleteBucket, branchName, repoName;
 
   if (eventType === 'pull_request') {
@@ -46,7 +46,7 @@ async function handleWebhookEvent(eventType, webhookBody) {
     return { statusCode: 200, message: message };
   }
 
-  const { shouldDeleteBucket, branchName, repoName } = parsewebhookBody(eventType, webhookBody);
+  const { shouldDeleteBucket, branchName, repoName } = parseWebhookBody(eventType, webhookBody);
 
   if (!shouldDeleteBucket) {
     const message = `Event should not delete bucket: shouldDeleteBucket: ${shouldDeleteBucket}, eventType: ${eventType}`;

--- a/DeleteS3FeatureBucket/index.js
+++ b/DeleteS3FeatureBucket/index.js
@@ -43,18 +43,18 @@ function parseWebhookBody(eventType, webhookBody) {
 async function handleWebhookEvent(eventType, webhookBody) {
   if (!['pull_request', 'delete'].includes(eventType)) {
     const message = `Event ignored. Event type: ${eventType}`;
-    return { statusCode: 200, message: message };
+    return { statusCode: 200, body: message };
   }
 
   const { shouldDeleteBucket, branchName, repoName } = parseWebhookBody(eventType, webhookBody);
 
   if (!shouldDeleteBucket) {
     const message = `Event should not delete bucket: shouldDeleteBucket: ${shouldDeleteBucket}, eventType: ${eventType}`;
-    return { statusCode: 200, message: message };
+    return { statusCode: 200, body: message };
   } else {
     const bucket = `${branchName}-${repoName}`;
     message = await deleteS3Bucket(bucket);
-    return { statusCode: 200,  message: message };
+    return { statusCode: 200,  body: message };
   }
 };
 

--- a/DeleteS3FeatureBucket/index.js
+++ b/DeleteS3FeatureBucket/index.js
@@ -1,75 +1,90 @@
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3();
 
-async function handleWebhookEvent(webhookBody) {
-    const action = webhookBody['action'];
-    const pullRequest = webhookBody['pull_request'];
-    let message = 'Event ignored';
+async function deleteS3Bucket(bucket) {
+  let objects;
 
-    // If no pull_request, ignore event
-    if(!pullRequest) {
-        return { statusCode: 200, message: message };
-    }
+  // List all object keys in the bucket
+  try {
+    let response = await s3.listObjects({Bucket: bucket}).promise();
+    objects = response['Contents'].map((object) => { return { 'Key': object['Key'] } });
+  } catch (e) {
+    console.log(e);
+    throw new Error(e);
+  }
 
-    const branchName = pullRequest['head']['ref'];
-    const repoName = pullRequest['head']['repo']['name'];
+  console.log({objects});
 
-    console.log({action});
-    console.log({branchName});
+  // Delete all the objects from the bucket
+  await s3.deleteObjects({Bucket: bucket, Delete: { Objects: objects }}).promise();
+  // Delete the bucket
+  await s3.deleteBucket({Bucket: bucket}).promise();
 
-    if(action === 'closed' && branchName != 'master') {
-        const bucket = `${branchName}-${repoName}`;
-        let objects;
+  return message = `S3 bucket deleted: ${bucket}`;
+};
 
-        // List all object keys in the bucket
-        try {
-          let response = await s3.listObjects({Bucket: bucket}).promise();
-          objects = response['Contents'].map((object) => { return { 'Key': object['Key'] } });
-        } catch (e) {
-          console.log(e);
-          throw new Error(e);
-        }
+function parsewebhookBody(eventType, webhookBody) {
+  let shouldDeleteBucket, branchName, repoName;
 
-        console.log({objects});
+  if (eventType === 'pull_request') {
+    branchName = webhookBody['pull_request']['head']['ref'];
+    repoName = webhookBody['pull_request']['head']['repo']['name'];
+    shouldDeleteBucket = webhookBody['action'] === 'closed' && branchName !== 'master';
+  } else if (eventType === 'delete') {
+    branchName = webhookBody['ref'];
+    repoName = webhookBody['repository']['name'];
+    shouldDeleteBucket = webhookBody['ref_type'] === 'branch' && branchName !== 'master';
+  };
 
-        // Delete all the objects from the bucket
-        await s3.deleteObjects({Bucket: bucket, Delete: { Objects: objects }}).promise();
-        // Delete the bucket
-        await s3.deleteBucket({Bucket: bucket}).promise();
-        message = `S3 bucket deleted: ${bucket}`;
-    } else {
-        message = "Pull request event ignored";
-    }
-    return { statusCode: 200, body: message };
+  console.log('shouldDeleteBucket: ', shouldDeleteBucket);
+  return { shouldDeleteBucket, branchName, repoName };
 }
 
+async function handleWebhookEvent(eventType, webhookBody) {
+  if (!['pull_request', 'delete'].includes(eventType)) {
+    const message = `Event ignored. Event type: ${eventType}`;
+    return { statusCode: 200, message: message };
+  }
+
+  const { shouldDeleteBucket, branchName, repoName } = parsewebhookBody(eventType, webhookBody);
+
+  if (!shouldDeleteBucket) {
+    const message = `Event should not delete bucket: shouldDeleteBucket: ${shouldDeleteBucket}, eventType: ${eventType}`;
+    return { statusCode: 200, message: message };
+  } else {
+    const bucket = `${branchName}-${repoName}`;
+    message = await deleteS3Bucket(bucket);
+    return { statusCode: 200,  message: message };
+  }
+};
+
 module.exports.handler = async (event, context) => {
-    console.log(`Event: ${JSON.stringify(event, null, 2)}`);
-    let response;
+  console.log(`Event: ${JSON.stringify(event, null, 2)}`);
+  let response;
 
-    if (!event.body) {
-        response = { statusCode: 403, body: 'Missing event body' };
-        console.log(`Response: ${JSON.stringify(response, null, 2)}`);
-        return response;
-    }
+  if (!event.body) {
+      response = { statusCode: 403, body: 'Missing event body' };
+      console.log(`Response: ${JSON.stringify(response, null, 2)}`);
+      return response;
+  }
 
+  let body;
+
+  try {
     // Parse the message body from the Lambda proxy
-    let body;
+    body = JSON.parse(event.body);
+  } catch (e) {
+    console.log(`Request Event Body is not JSON: ${event.body}`)
+    console.log(`Error: ${e}`)
+    response = { statusCode: 200, body: 'Event body is not JSON, Ignoring event' };
+    return response
+  }
 
-    try {
-      body = JSON.parse(event.body);
-    } catch (e) {
-      console.log(`Request Event Body is not JSON: ${event.body}`)
-      console.log(`Error: ${e}`)
-      response = { statusCode: 200, body: 'Event body is not JSON, Ignoring event' };
-      return response
-    }
+  console.log(`Event body: ${JSON.stringify(body, null, 2)}`);
 
-    console.log(`Event body: ${JSON.stringify(body, null, 2)}`);
+  const gitHubEvent = event.headers['X-GitHub-Event'];
+  response = await handleWebhookEvent(gitHubEvent, body);
 
-    // Handle the webhook event
-    response = await handleWebhookEvent(body);
-
-    console.log(`Response: ${JSON.stringify(response, null, 2)}`);
-    return response;
+  console.log(`Response: ${JSON.stringify(response, null, 2)}`);
+  return response;
 };


### PR DESCRIPTION
This PR updates the behavior of both `DeleteCFStack` and `DeleteS3FeatureBucket` to respond to ['delete' events](https://developer.github.com/v3/activity/events/types/#deleteevent) so that deleting remote branches also deletes the appropriate AWS resources.

Note: When this is deployed, we'll want to update the webhooks in the [hobbes](https://github.com/educationsuperhighway/hobbes) and [baloo](https://github.com/educationsuperhighway/baloo) repos.